### PR TITLE
add eshost state + storage

### DIFF
--- a/terraform/states/eshost/storage.tf
+++ b/terraform/states/eshost/storage.tf
@@ -1,0 +1,29 @@
+##
+# TODO: documentation about how this will be used.
+#
+resource "aws_s3_bucket" "builds" {
+  bucket = "eshost-builds"
+  region = "us-east-1"
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicReadGetObject",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::eshost-builds",
+        "arn:aws:s3:::eshost-builds/*"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/terraform/states/eshost/storage.tf
+++ b/terraform/states/eshost/storage.tf
@@ -1,5 +1,6 @@
 ##
-# TODO: documentation about how this will be used.
+# This will be used to store pre-built cross-compiled binaries for a variety of
+# JavaScript engines and runtimes.
 #
 resource "aws_s3_bucket" "builds" {
   bucket = "eshost-builds"

--- a/terraform/states/eshost/variables.tf
+++ b/terraform/states/eshost/variables.tf
@@ -1,0 +1,23 @@
+##
+# This tells Terraform how to authenticate for AWS resources. It expects
+# an entry in ~/.aws/credentials with a matching profile. You can create
+# this with `aws configure --profile web-platform`.
+#
+provider "aws" {
+  profile = "web-platform"
+  region = "us-east-1"
+}
+
+##
+# This tells Terraform where to persist the state of the infrastructure for
+# this project. We use S3 so the state doesn't have to be manually checked
+# into the repository.
+#
+terraform {
+  backend "s3" {
+    bucket = "web-platform-terraform"
+    key = "eshost.tfstate"
+    region = "us-east-1"
+    profile = "web-platform"
+  }
+}


### PR DESCRIPTION
To check the new functionality this gives you, run the following:

**ensure you can talk to aws at the command line**
```
brew install awscli
```

**get your aws creds**
```
ssh nest.bocoup.com "cat creds"
```

**configure aws** (this creates the file ~/.aws/credentials)
```
❯ aws configure --profile=web-platform
AWS Access Key ID [None]: <enter id from above>
AWS Secret Access Key [None]: <enter key from above>
Default region name [None]: us-east-1
Default output format [None]: <hit enter>
```

**ensure you can interact with the eshost-builds bucket**
```
echo hi rick > file
aws s3 cp file s3://eshost-builds --profile=web-platform
aws s3 ls s3://eshost-builds --profile=web-platform
curl https://s3.amazonaws.com/eshost-builds/file
aws rm s3://eshost-builds/file --profile=web-platform
```

Have we purchased a domain for this stuff yet? I could make this bucket accessible from like `http://web-platform.io/eshost-builds/whatever.tar.gz` if we want to control the URL for the long term (thinking of a future where this is no longer on AWS but we have hard-coded URLs elsewhere using it).