### PR TITLE
web-platform-tests.live: Honor non-existent domain

### DIFF
--- a/terraform/projects/web-platform-tests-live/network.tf
+++ b/terraform/projects/web-platform-tests-live/network.tf
@@ -39,6 +39,18 @@ resource "aws_route53_record" "web_platform_tests_live_CNAME_wildcard-web_platfo
   records = ["web-platform-tests.live"]
 }
 
+# WPT endorses the use of the subdomain `nonexistent` for tests which require a
+# non-existent host. An explicit CNAME record overrides the "wildcard" record
+# defined above in order to ensure that requests to this particular subdomain
+# do not resolve.
+resource "aws_route53_record" "web_platform_tests_live_CNAME_nonexistent-web_platform_tests_live" {
+  zone_id = "${aws_route53_zone.web_platform_tests_live.zone_id}"
+  type = "CNAME"
+  name = "nonexistent"
+  ttl = "1"
+  records = ["0.0.0.0"]
+}
+
 ## alternate domain dns records
 resource "aws_route53_zone" "not_web_platform_tests_live" {
   name = "not-web-platform-tests.live"
@@ -64,6 +76,18 @@ resource "aws_route53_record" "not_web_platform_tests_live_CNAME_wildcard-not_we
   name = "*"
   ttl = "1"
   records = ["not-web-platform-tests.live"]
+}
+
+# WPT endorses the use of the subdomain `nonexistent` for tests which require a
+# non-existent host. An explicit CNAME record overrides the "wildcard" record
+# defined above in order to ensure that requests to this particular subdomain
+# do not resolve.
+resource "aws_route53_record" "web_platform_tests_live_CNAME_nonexistent-not-web_platform_tests_live" {
+  zone_id = "${aws_route53_zone.web_platform_tests_live.zone_id}"
+  type = "CNAME"
+  name = "nonexistent"
+  ttl = "1"
+  records = ["0.0.0.0"]
 }
 
 module "web_platform_tests_live_http_health_check" {

--- a/terraform/projects/web-platform-tests-live/terraform.tfstate
+++ b/terraform/projects/web-platform-tests-live/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
-    "terraform_version": "0.11.7",
-    "serial": 35,
+    "terraform_version": "0.11.11",
+    "serial": 37,
     "lineage": "2c7f9dee-e110-7156-26d0-9033dbc2285d",
     "modules": [
         {
@@ -31,6 +31,7 @@
                             "network_interface": "eni-6a4a915a",
                             "private_ip": "10.100.0.214",
                             "public_ip": "18.211.123.192",
+                            "public_ipv4_pool": "amazon",
                             "tags.%": "0",
                             "vpc": "true"
                         },
@@ -57,8 +58,11 @@
                         "id": "i-07b857e5803ba6855",
                         "attributes": {
                             "ami": "ami-5cc39523",
+                            "arn": "arn:aws:ec2:us-east-1:682416359150:instance/i-07b857e5803ba6855",
                             "associate_public_ip_address": "true",
                             "availability_zone": "us-east-1a",
+                            "cpu_core_count": "1",
+                            "cpu_threads_per_core": "1",
                             "credit_specification.#": "1",
                             "credit_specification.0.cpu_credits": "standard",
                             "disable_api_termination": "false",
@@ -197,6 +201,58 @@
                     "deposed": [],
                     "provider": "provider.aws"
                 },
+                "aws_route53_record.web_platform_tests_live_CNAME_nonexistent-not-web_platform_tests_live": {
+                    "type": "aws_route53_record",
+                    "depends_on": [
+                        "aws_route53_zone.web_platform_tests_live"
+                    ],
+                    "primary": {
+                        "id": "Z2838GFD690E91_nonexistent_CNAME",
+                        "attributes": {
+                            "allow_overwrite": "true",
+                            "fqdn": "nonexistent.web-platform-tests.live",
+                            "id": "Z2838GFD690E91_nonexistent_CNAME",
+                            "name": "nonexistent",
+                            "records.#": "1",
+                            "records.3771769585": "0.0.0.0",
+                            "ttl": "1",
+                            "type": "CNAME",
+                            "zone_id": "Z2838GFD690E91"
+                        },
+                        "meta": {
+                            "schema_version": "2"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
+                "aws_route53_record.web_platform_tests_live_CNAME_nonexistent-web_platform_tests_live": {
+                    "type": "aws_route53_record",
+                    "depends_on": [
+                        "aws_route53_zone.web_platform_tests_live"
+                    ],
+                    "primary": {
+                        "id": "Z2838GFD690E91_nonexistent_CNAME",
+                        "attributes": {
+                            "allow_overwrite": "true",
+                            "fqdn": "nonexistent.web-platform-tests.live",
+                            "id": "Z2838GFD690E91_nonexistent_CNAME",
+                            "name": "nonexistent",
+                            "records.#": "1",
+                            "records.3771769585": "0.0.0.0",
+                            "ttl": "1",
+                            "type": "CNAME",
+                            "zone_id": "Z2838GFD690E91"
+                        },
+                        "meta": {
+                            "schema_version": "2"
+                        },
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": "provider.aws"
+                },
                 "aws_route53_record.web_platform_tests_live_CNAME_wildcard-web_platform_tests_live": {
                     "type": "aws_route53_record",
                     "depends_on": [
@@ -232,15 +288,19 @@
                         "id": "Z1Q87OR1ICW3E7",
                         "attributes": {
                             "comment": "Managed by Terraform",
+                            "delegation_set_id": "",
                             "force_destroy": "false",
                             "id": "Z1Q87OR1ICW3E7",
-                            "name": "not-web-platform-tests.live",
+                            "name": "not-web-platform-tests.live.",
                             "name_servers.#": "4",
                             "name_servers.0": "ns-1391.awsdns-45.org",
                             "name_servers.1": "ns-1613.awsdns-09.co.uk",
                             "name_servers.2": "ns-504.awsdns-63.com",
                             "name_servers.3": "ns-781.awsdns-33.net",
                             "tags.%": "0",
+                            "vpc.#": "0",
+                            "vpc_id": "",
+                            "vpc_region": "",
                             "zone_id": "Z1Q87OR1ICW3E7"
                         },
                         "meta": {},
@@ -256,15 +316,19 @@
                         "id": "Z2838GFD690E91",
                         "attributes": {
                             "comment": "Managed by Terraform",
+                            "delegation_set_id": "",
                             "force_destroy": "false",
                             "id": "Z2838GFD690E91",
-                            "name": "web-platform-tests.live",
+                            "name": "web-platform-tests.live.",
                             "name_servers.#": "4",
                             "name_servers.0": "ns-139.awsdns-17.com",
                             "name_servers.1": "ns-1440.awsdns-52.org",
                             "name_servers.2": "ns-1571.awsdns-04.co.uk",
                             "name_servers.3": "ns-547.awsdns-04.net",
                             "tags.%": "0",
+                            "vpc.#": "0",
+                            "vpc_id": "",
+                            "vpc_region": "",
                             "zone_id": "Z2838GFD690E91"
                         },
                         "meta": {},
@@ -301,6 +365,7 @@
                             "ingress.482069346.description": "",
                             "ingress.482069346.from_port": "0",
                             "ingress.482069346.ipv6_cidr_blocks.#": "0",
+                            "ingress.482069346.prefix_list_ids.#": "0",
                             "ingress.482069346.protocol": "-1",
                             "ingress.482069346.security_groups.#": "0",
                             "ingress.482069346.self": "false",
@@ -391,16 +456,23 @@
                     "type": "aws_availability_zones",
                     "depends_on": [],
                     "primary": {
-                        "id": "2018-10-25 17:22:20.300486356 +0000 UTC",
+                        "id": "2019-02-11 21:40:13.099517199 +0000 UTC",
                         "attributes": {
-                            "id": "2018-10-25 17:22:20.300486356 +0000 UTC",
+                            "id": "2019-02-11 21:40:13.099517199 +0000 UTC",
                             "names.#": "6",
                             "names.0": "us-east-1a",
                             "names.1": "us-east-1b",
                             "names.2": "us-east-1c",
                             "names.3": "us-east-1d",
                             "names.4": "us-east-1e",
-                            "names.5": "us-east-1f"
+                            "names.5": "us-east-1f",
+                            "zone_ids.#": "6",
+                            "zone_ids.0": "use1-az6",
+                            "zone_ids.1": "use1-az1",
+                            "zone_ids.2": "use1-az2",
+                            "zone_ids.3": "use1-az4",
+                            "zone_ids.4": "use1-az3",
+                            "zone_ids.5": "use1-az5"
                         },
                         "meta": {},
                         "tainted": false
@@ -466,6 +538,7 @@
                         "id": "igw-0d38756b",
                         "attributes": {
                             "id": "igw-0d38756b",
+                            "owner_id": "682416359150",
                             "tags.%": "1",
                             "tags.Name": "web-platform",
                             "vpc_id": "vpc-eb65f992"
@@ -503,6 +576,7 @@
                             "ingress.1401401844.protocol": "-1",
                             "ingress.1401401844.rule_no": "100",
                             "ingress.1401401844.to_port": "0",
+                            "owner_id": "682416359150",
                             "subnet_ids.#": "3",
                             "subnet_ids.2117191030": "subnet-d049defc",
                             "subnet_ids.3084702540": "subnet-7b068921",
@@ -536,6 +610,7 @@
                             "origin": "CreateRoute",
                             "route_table_id": "rtb-5452702c",
                             "state": "active",
+                            "transit_gateway_id": "",
                             "vpc_peering_connection_id": ""
                         },
                         "meta": {
@@ -556,16 +631,18 @@
                         "id": "rtb-5452702c",
                         "attributes": {
                             "id": "rtb-5452702c",
+                            "owner_id": "682416359150",
                             "propagating_vgws.#": "0",
                             "route.#": "1",
-                            "route.3213985265.cidr_block": "0.0.0.0/0",
-                            "route.3213985265.egress_only_gateway_id": "",
-                            "route.3213985265.gateway_id": "igw-0d38756b",
-                            "route.3213985265.instance_id": "",
-                            "route.3213985265.ipv6_cidr_block": "",
-                            "route.3213985265.nat_gateway_id": "",
-                            "route.3213985265.network_interface_id": "",
-                            "route.3213985265.vpc_peering_connection_id": "",
+                            "route.1574494455.cidr_block": "0.0.0.0/0",
+                            "route.1574494455.egress_only_gateway_id": "",
+                            "route.1574494455.gateway_id": "igw-0d38756b",
+                            "route.1574494455.instance_id": "",
+                            "route.1574494455.ipv6_cidr_block": "",
+                            "route.1574494455.nat_gateway_id": "",
+                            "route.1574494455.network_interface_id": "",
+                            "route.1574494455.transit_gateway_id": "",
+                            "route.1574494455.vpc_peering_connection_id": "",
                             "tags.%": "1",
                             "tags.Name": "web-platform",
                             "vpc_id": "vpc-eb65f992"
@@ -630,11 +707,16 @@
                     "primary": {
                         "id": "subnet-7b068921",
                         "attributes": {
+                            "arn": "arn:aws:ec2:us-east-1:682416359150:subnet/subnet-7b068921",
                             "assign_ipv6_address_on_creation": "false",
                             "availability_zone": "us-east-1a",
+                            "availability_zone_id": "use1-az6",
                             "cidr_block": "10.100.0.0/24",
                             "id": "subnet-7b068921",
+                            "ipv6_cidr_block": "",
+                            "ipv6_cidr_block_association_id": "",
                             "map_public_ip_on_launch": "true",
+                            "owner_id": "682416359150",
                             "tags.%": "1",
                             "tags.Name": "web-platform-0",
                             "vpc_id": "vpc-eb65f992"
@@ -653,11 +735,16 @@
                     "primary": {
                         "id": "subnet-a28760c6",
                         "attributes": {
+                            "arn": "arn:aws:ec2:us-east-1:682416359150:subnet/subnet-a28760c6",
                             "assign_ipv6_address_on_creation": "false",
                             "availability_zone": "us-east-1b",
+                            "availability_zone_id": "use1-az1",
                             "cidr_block": "10.100.1.0/24",
                             "id": "subnet-a28760c6",
+                            "ipv6_cidr_block": "",
+                            "ipv6_cidr_block_association_id": "",
                             "map_public_ip_on_launch": "true",
+                            "owner_id": "682416359150",
                             "tags.%": "1",
                             "tags.Name": "web-platform-1",
                             "vpc_id": "vpc-eb65f992"
@@ -676,11 +763,16 @@
                     "primary": {
                         "id": "subnet-d049defc",
                         "attributes": {
+                            "arn": "arn:aws:ec2:us-east-1:682416359150:subnet/subnet-d049defc",
                             "assign_ipv6_address_on_creation": "false",
                             "availability_zone": "us-east-1c",
+                            "availability_zone_id": "use1-az2",
                             "cidr_block": "10.100.2.0/24",
                             "id": "subnet-d049defc",
+                            "ipv6_cidr_block": "",
+                            "ipv6_cidr_block_association_id": "",
                             "map_public_ip_on_launch": "true",
+                            "owner_id": "682416359150",
                             "tags.%": "1",
                             "tags.Name": "web-platform-2",
                             "vpc_id": "vpc-eb65f992"
@@ -720,6 +812,7 @@
                     "primary": {
                         "id": "vpc-eb65f992",
                         "attributes": {
+                            "arn": "arn:aws:ec2:us-east-1:682416359150:vpc/vpc-eb65f992",
                             "assign_generated_ipv6_cidr_block": "false",
                             "cidr_block": "10.100.0.0/16",
                             "default_network_acl_id": "acl-48000631",
@@ -732,7 +825,10 @@
                             "enable_dns_support": "true",
                             "id": "vpc-eb65f992",
                             "instance_tenancy": "default",
+                            "ipv6_association_id": "",
+                            "ipv6_cidr_block": "",
                             "main_route_table_id": "rtb-0a507272",
+                            "owner_id": "682416359150",
                             "tags.%": "1",
                             "tags.Name": "web-platform"
                         },
@@ -767,6 +863,7 @@
                             "alarm_actions.773202137": "arn:aws:sns:us-east-1:682416359150:web-platform-domains-health-check",
                             "alarm_description": "Health monitoring for http://web-platform-tests.live.",
                             "alarm_name": "Health of http://web-platform-tests.live",
+                            "arn": "arn:aws:cloudwatch:us-east-1:682416359150:alarm:Health of http://web-platform-tests.live",
                             "comparison_operator": "LessThanThreshold",
                             "datapoints_to_alarm": "0",
                             "dimensions.%": "1",
@@ -847,6 +944,7 @@
                             "alarm_actions.773202137": "arn:aws:sns:us-east-1:682416359150:web-platform-domains-health-check",
                             "alarm_description": "Health monitoring for https://web-platform-tests.live.",
                             "alarm_name": "Health of https://web-platform-tests.live",
+                            "arn": "arn:aws:cloudwatch:us-east-1:682416359150:alarm:Health of https://web-platform-tests.live",
                             "comparison_operator": "LessThanThreshold",
                             "datapoints_to_alarm": "0",
                             "dimensions.%": "1",


### PR DESCRIPTION
In commit 111587c777e4e05 we accommodated future changes to WPT's list
of available subdomains by introducing a "wildcard" DNS entry. This had
the unintended side-effect of enabling the domain which that project
explicitly endorses as non-existent
(nonexistent.web-platform-tests.live). Resolve this with a dedicated DNS
CNAME record, ensuring that requests to that particular domain do not
resolve.